### PR TITLE
make the shared dev db more share-able via schemas

### DIFF
--- a/apps/next/app/api/user/whoami/route.ts
+++ b/apps/next/app/api/user/whoami/route.ts
@@ -1,5 +1,8 @@
+import { db } from "@/app/server/db";
+import { users } from "@/app/server/db/schema";
 import { clerkClient } from "@clerk/nextjs";
 import { decodeJwt } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
 
 export const dynamic = "force-dynamic";
 
@@ -11,10 +14,38 @@ export async function GET(request: Request) {
     });
   }
   const { payload: token } = decodeJwt(authStatus.token);
-  const userId = token.sub;
-  const user = await clerkClient.users.getUser(userId);
+  const clerkUserId = token.sub;
+  try {
+    const user = await clerkClient.users.getUser(clerkUserId);
+  } catch (error: any) {
+    if (error.clerkError && error.errors.length > 0) {
+      // handle resource_not_found (i.e. clerk user deleted)
+      if (error.errors[0].code === "resource_not_found") {
+        return new Response(JSON.stringify({}), {
+          status: 401,
+        });
+      }
+      console.error(JSON.stringify(error.errors[0]));
+    }
+    throw error;
+  }
 
-  return new Response(JSON.stringify({ token, user }, null, 2), {
-    status: 200,
-  });
+  // response is the user object in our db along with the token for api access
+  const user = await db
+    .select()
+    .from(users)
+    .where(eq(users.clerkId, clerkUserId))
+    .limit(1)
+    .then((rows) => rows[0] || null);
+  if (!user) {
+    return new Response(JSON.stringify({}), {
+      status: 404,
+    });
+  }
+  return new Response(
+    JSON.stringify({ token: authStatus.token, user }, null, 2),
+    {
+      status: 200,
+    }
+  );
 }

--- a/apps/next/app/server/db/nuke.ts
+++ b/apps/next/app/server/db/nuke.ts
@@ -1,0 +1,29 @@
+import { db } from "./index";
+import { sql } from "drizzle-orm";
+import sqlSchemaForEnv from "./schemaForEnv";
+
+const nuke = async (): Promise<void> => {
+  const env = process.env.NODE_ENV;
+  if (!env || env === "production") {
+    console.log("refusing to nuke the db");
+    process.exit(1);
+  }
+
+  const sqlSchema = sqlSchemaForEnv(process.env.NODE_ENV);
+  const tables = await db.execute(
+    sql.raw(`SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = '${sqlSchema}'
+        AND table_type = 'BASE TABLE';
+    `)
+  );
+
+  for (let table of tables) {
+    const query = sql.raw(`DROP TABLE ${table.table_name} CASCADE;`);
+    await db.execute(query);
+  }
+  console.log("finished nuking the db");
+  process.exit(0);
+};
+
+nuke();

--- a/apps/next/app/server/db/schema.ts
+++ b/apps/next/app/server/db/schema.ts
@@ -7,11 +7,26 @@ import {
   primaryKey,
   serial,
   text,
+  pgEnum,
   timestamp,
+  pgSchema,
 } from "drizzle-orm/pg-core";
+import sqlSchemaForEnv from "./schemaForEnv";
 
-export const users = pgTable(
-  "metal_users",
+const createdAndUpdatedAt = {
+  createdAt: timestamp("created_at")
+    .default(sql`CURRENT_TIMESTAMP`)
+    .notNull(),
+  updatedAt: timestamp("updated_at")
+    .default(sql`CURRENT_TIMESTAMP`)
+    .notNull()
+    .$onUpdateFn(() => new Date()),
+};
+
+export const metalSchema = pgSchema(sqlSchemaForEnv(process.env.NODE_ENV));
+
+export const users = metalSchema.table(
+  "users",
   {
     id: serial("id").primaryKey(),
     clerkId: text("clerk_id").unique().notNull(),
@@ -20,13 +35,7 @@ export const users = pgTable(
     email: text("email").notNull(),
     emailVerified: boolean("email_verified").notNull().default(false),
     githubId: text("github_id").$type<string | null>(),
-    createdAt: timestamp("created_at", { precision: 3 })
-      .default(sql`current_timestamp(3)`)
-      .notNull(),
-    updatedAt: timestamp("updatedAt")
-      .default(sql`current_timestamp(3)`)
-      .notNull()
-      .$onUpdateFn(() => new Date()),
+    ...createdAndUpdatedAt,
   },
   (example) => ({
     clerkIndex: index("clerk_id").on(example.clerkId),
@@ -36,34 +45,33 @@ export const users = pgTable(
 export type User = typeof users.$inferSelect; // return type when queried
 export type UserInsert = typeof users.$inferInsert;
 
-export const usersRelations = relations(users, ({ many }) => ({
+export const userRelations = relations(users, ({ many }) => ({
   usersToTeams: many(usersToTeams), // user can belong to many teams, a team can have many users
 }));
 
-export const teams = pgTable("metal_teams", {
+export const teams = metalSchema.table("teams", {
   id: serial("id").primaryKey(),
   clerkId: text("clerk_id").unique().notNull(),
   name: text("name").notNull(),
   creatorId: integer("creator_id"),
-  createdAt: timestamp("created_at")
-    .default(sql`CURRENT_TIMESTAMP`)
-    .notNull(),
-  updatedAt: timestamp("updatedAt"),
+  ...createdAndUpdatedAt,
 });
 export type Team = typeof teams.$inferSelect; // return type when queried
 export type TeamInsert = typeof teams.$inferInsert;
 
-export const teamsRelations = relations(teams, ({ one, many }) => ({
+export const teamRelations = relations(teams, ({ one, many }) => ({
   creator: one(users, {
     fields: [teams.creatorId],
     references: [users.id],
   }),
   usersToTeams: many(usersToTeams),
+  hetznerProjects: many(hetznerProjects),
+  hetznerClusters: many(hetznerClusters),
 }));
 
 // usersToTeams tracks a many-to-many relation between users and teams
-export const usersToTeams = pgTable(
-  "metal_users_to_teams",
+export const usersToTeams = metalSchema.table(
+  "users_to_teams",
   {
     userId: integer("user_id")
       .notNull()
@@ -86,3 +94,148 @@ export const usersToTeamsRelations = relations(usersToTeams, ({ one }) => ({
     references: [users.id],
   }),
 }));
+
+// hetznerProjects. Hetzner requires all resources to be created within the confines of a project.
+// A Hetzner project is also what we ask users to connect to Metal.
+// This table contains the information provided by users about a Hetzner project in their Hetzner account.
+// Once we have this Hetzner project info we can start creating things in their Hetzner account.
+// We associate them with the user who created them, the team they belong to, and the clusters they contain.
+export const hetznerProjects = metalSchema.table("hetzner_projects", {
+  id: serial("id").primaryKey(),
+  creatorId: integer("creator_id").notNull(),
+  teamId: integer("team_id").notNull(),
+  hetznerName: text("hetzner_project_name").notNull(),
+  hetznerApiToken: text("hetzner_api_token").notNull(),
+  publicSshKeyData: text("public_ssh_key_data").notNull(),
+  privateSshKeyData: text("private_ssh_key_data").notNull(),
+  hetznerWebserviceUsername: text("hetzner_web_service_username").$type<
+    string | null
+  >(),
+  hetznerWebservicePassword: text("hetzner_web_service_password").$type<
+    string | null
+  >(),
+  ...createdAndUpdatedAt,
+});
+
+export const hetznerProjectRelations = relations(
+  hetznerProjects,
+  ({ one, many }) => ({
+    creatorId: one(users, {
+      fields: [hetznerProjects.creatorId],
+      references: [users.id],
+    }),
+    teamId: one(teams, {
+      fields: [hetznerProjects.teamId],
+      references: [teams.id],
+    }),
+    clusters: many(hetznerClusters),
+  })
+);
+
+// Hetzner thinks of geography as "network zones" at the highest level.
+// Within each network zone are locations.
+export const hetznerNetworkZoneEnum = pgEnum("hetzner_network_zone_enum", [
+  "eu-central",
+  "us-east",
+  "us-west",
+]);
+export const hetznerLocationEnum = pgEnum("hetzner_location_enum", [
+  "fsn1", // eu-central
+  "nbg1", // eu-central
+  "hel1", // eu-central
+  "ash", // us-east
+  "hil", // us-west
+]);
+
+export const hetznerClusterStatusEnum = pgEnum("hetzner_cluster_status_enum", [
+  "creating", // waiting for the k8s cluster api to finish its thing
+  "initializing", // doing additional installs on the cluster
+  "running", // all the nodes are up and running
+  "updating", // updating the cluster
+  "destroying", // destroying the cluster
+  "destroyed", // the cluster is fully destroyed
+  "error", // something went wrong
+]);
+
+// hetznerClusters. This represents k8s clusters that we spin up within a user's Hetzner account.
+export const hetznerClusters = metalSchema.table("hetzner_clusters", {
+  id: serial("id").primaryKey(),
+  creatorId: integer("creator_id").notNull(),
+  teamId: integer("team_id").notNull(),
+  hetznerProjectId: integer("hetzner_project_id").notNull(),
+  name: text("name").notNull(), // what we call it in the cluster api (assigned)
+  vanityName: text("vanity_name").notNull(), // name the user gave it
+  status: hetznerClusterStatusEnum("status").notNull(),
+  networkZone: hetznerNetworkZoneEnum("network_zone").notNull(),
+  cidr: text("cidr").notNull(),
+  location: hetznerLocationEnum("location").notNull(),
+  k8sVersion: text("k8s_version").notNull(),
+  ...createdAndUpdatedAt,
+});
+
+export const hetznerClusterRelations = relations(
+  hetznerClusters,
+  ({ one, many }) => ({
+    creatorId: one(users, {
+      fields: [hetznerClusters.creatorId],
+      references: [users.id],
+    }),
+    teamId: one(teams, {
+      fields: [hetznerClusters.creatorId],
+      references: [teams.id],
+    }),
+    hetznerProjectId: one(hetznerProjects, {
+      fields: [hetznerClusters.creatorId],
+      references: [hetznerProjects.id],
+    }),
+    nodeGroups: many(hetznerNodeGroups),
+  })
+);
+
+export const nodeGroupTypeEnum = pgEnum("node_group_type_enum", ["all"]); // future support for different types as a cluster gets bigger: "application", "system", "monitoring", "ingress"
+export const hetznerInstanceTypeEnum = pgEnum("hetzner_instance_type_enum", [
+  // Cloud Shared AMD and Cloud Dedicated AMD are available in all locations, so list those out
+  // https://docs.hetzner.com/cloud/general/locations/#which-cloud-products-are-available
+  // amd shared: (knock off 0.50 for ipv6 only. all come with 20 TB traffic)
+  "cpx11", // 2 vcpu, 2 gb ram, 20 gb disk, 4.35/mo
+  "cpx21", // 3 vcpu, 4 gb ram, 80 gb disk, 7.55/mo
+  "cpx31", // 4 vcpu, 8 gb ram, 160 gb disk, 13.60/mo
+  "cpx41", // 8 vcpu, 16 gb ram, 240 gb disk, 25.20/mo
+  "cpx51", // 16 vcpu, 32 gb ram, 360 gb disk, 54.90/mo
+  // amd dedicated: (also knock off 0.50 for ipv6 only. range from 20 to 60 TB traffic)
+  // "ccx13", // 2 vcpu, 8 gb ram, 80 gb disk, 12.49/mo
+  // "ccx23", // 4 vcpu, 16 gb ram, 160 gb disk, 24.49/mo
+  // "ccx33", // 8 vcpu, 32 gb ram, 240 gb disk, 48.49/mo
+  // "ccx43", // 16 vcpu, 64 gb ram, 360 gb disk, 96.49/mo
+  // "ccx53", // 32 vcpu, 128 gb ram, 600 gb disk, 192.49/mo
+  // "ccx63", // 48 vcpu, 192 gb ram, 950 gb disk, 288.49/mo
+  // Cloud Shared ARM is cheap, but
+  // - there would probably be difficulties building apps targeting ARM
+  // - only available in fsn1, nbg1, hel1 (no us)
+  // (knock off 0.50 for ipv6 only. all come with 20 TB traffic)
+  "cax11", // 2 vcpu, 4 gb ram, 40 gb disk, 3.79/mo
+  "cax21", // 4 vcpu, 8 gb ram, 80 gb disk, 6.49/mo
+  "cax31", // 8 vcpu, 16 gb ram, 160 gb disk, 12.49/mo
+  "cax41", // 16 vcpu, 32 gb ram, 320 gb disk, 24.49/mo
+]);
+
+// hetznerNodeGroups subdivide clusters and provide isolation for different workload types.
+export const hetznerNodeGroups = metalSchema.table("hetzner_node_group", {
+  id: serial("id").primaryKey(),
+  clusterId: integer("cluster_id").notNull(),
+  type: nodeGroupTypeEnum("type").notNull(),
+  instanceType: hetznerInstanceTypeEnum("instance_type").notNull(),
+  minNodes: integer("min_nodes").notNull(),
+  maxNodes: integer("max_nodes").notNull(),
+  ...createdAndUpdatedAt,
+});
+
+export const hetznerNodeGroupRelations = relations(
+  hetznerNodeGroups,
+  ({ one }) => ({
+    hetznerCluster: one(hetznerClusters, {
+      fields: [hetznerNodeGroups.clusterId],
+      references: [hetznerClusters.id],
+    }),
+  })
+);

--- a/apps/next/app/server/db/schemaForEnv.ts
+++ b/apps/next/app/server/db/schemaForEnv.ts
@@ -1,0 +1,15 @@
+import os from "os";
+
+export default function sqlSchemaForEnv(
+  env: "development" | "production" | "test"
+) {
+  const username = os.userInfo().username;
+  switch (env) {
+    case "development":
+      return `metaldev_${username}`;
+    case "test":
+      return `metaltest_${username}`;
+    case "production":
+      return "metalprod";
+  }
+}

--- a/apps/next/drizzle.config.ts
+++ b/apps/next/drizzle.config.ts
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import type { Config } from "drizzle-kit";
 import tmp from "tmp";
 import { writeFileSync } from "fs";
+import sqlSchemaForEnv from "@/app/server/db/schemaForEnv";
 dotenv.config();
 console.log("process.env.POSTGRES_URL", process.env.POSTGRES_URL);
 
@@ -26,7 +27,7 @@ export default {
   dbCredentials: {
     connectionString,
   },
-  tablesFilter: ["metal_*"],
+  schemaFilter: sqlSchemaForEnv(process.env.NODE_ENV),
   strict: true,
   verbose: true,
 } satisfies Config;

--- a/apps/next/package.json
+++ b/apps/next/package.json
@@ -12,6 +12,7 @@
     "build": "concurrently --raw \"npm:build:next\" \"npm:build:temporal\"",
     "db:push": "source $HOME/.nvm/nvm.sh; nvm use 20; drizzle-kit push:pg",
     "db:studio": "source $HOME/.nvm/nvm.sh; nvm use 20; drizzle-kit studio",
+    "db:nuke": "bun run ./app/server/db/nuke.ts",
     "dev:next": "next dev",
     "dev:otel-collector": "cd hack/opentelemetry-collector-dev-setup && docker-compose up",
     "dev:temporal": "tsx --env-file .env.development --watch --watch-preserve-output temporal/src/worker.ts",


### PR DESCRIPTION
- adds a env and user-specific pg schema so that we don't step on toes. Also makes it obvious when `bun run db:push` proposes doing destructive things that it will do it in a contained way.
- because of ^ got rid of `metal_` prefix convention on table names
- beginnings of a data model for hetzner resources
- `db:nuke` for quickly hitting reset on the db
- tweak the variable name for relation objects to `{singular table name}Relations` e.g. `userRelations` instead of `usersRelations`. Seems more natural (e.g. "a user has these relations")

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 765a6e7ddcac1bef029ccff895783376001692f1  | 
|--------|

### Summary:
This PR enhances the shareability of the shared development database by introducing environment and user-specific PostgreSQL schemas, removing the `metal_` prefix from table names, adding a data model for Hetzner resources, and providing a `db:nuke` command for database reset.

**Key points**:
- Introduced environment and user-specific PostgreSQL schemas.
- Removed `metal_` prefix convention from table names.
- Added initial data model for Hetzner resources.
- Added `db:nuke` command for resetting the database.
- Changed variable name for relation objects to `{singular table name}Relations`.
- Changes spread across `nuke.ts`, `schema.ts`, `schemaForEnv.ts`, `drizzle.config.ts`, and `package.json`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
