### PR TITLE
tweak cli a bit

### DIFF
--- a/apps/next/app/api/user/whoami/route.ts
+++ b/apps/next/app/api/user/whoami/route.ts
@@ -1,5 +1,8 @@
+import { db } from "@/app/server/db";
+import { users } from "@/app/server/db/schema";
 import { clerkClient } from "@clerk/nextjs";
 import { decodeJwt } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
 
 export const dynamic = "force-dynamic";
 
@@ -11,10 +14,38 @@ export async function GET(request: Request) {
     });
   }
   const { payload: token } = decodeJwt(authStatus.token);
-  const userId = token.sub;
-  const user = await clerkClient.users.getUser(userId);
+  const clerkUserId = token.sub;
+  try {
+    const user = await clerkClient.users.getUser(clerkUserId);
+  } catch (error: any) {
+    if (error.clerkError && error.errors.length > 0) {
+      // handle resource_not_found (i.e. clerk user deleted)
+      if (error.errors[0].code === "resource_not_found") {
+        return new Response(JSON.stringify({}), {
+          status: 401,
+        });
+      }
+      console.error(JSON.stringify(error.errors[0]));
+    }
+    throw error;
+  }
 
-  return new Response(JSON.stringify({ token, user }, null, 2), {
-    status: 200,
-  });
+  // response is the user object in our db along with the token for api access
+  const user = await db
+    .select()
+    .from(users)
+    .where(eq(users.clerkId, clerkUserId))
+    .limit(1)
+    .then((rows) => rows[0] || null);
+  if (!user) {
+    return new Response(JSON.stringify({}), {
+      status: 404,
+    });
+  }
+  return new Response(
+    JSON.stringify({ token: authStatus.token, user }, null, 2),
+    {
+      status: 200,
+    }
+  );
 }


### PR DESCRIPTION
previously we were doing two things that weren't very useful:
- in the cli, we were storing clerk user id which isn't very helpful in the context of future api requests where we need our db's user id
- in the whoami api response we weren't returning the user object in our db

this pr fixes both of those things

<!--
ELLIPSIS_HIDDEN
-->
----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6c164b237bdf81ce6ae3f9035ffcb0bf9a01452f  | 
|--------|

### Summary:
This PR enhances user identification in the CLI and API by introducing a new API client class, updating the user schema, and modifying the `whoami` API response.

**Key points**:
- Introduced `MetalApiClient` class in `/apps/cli/src/index.ts` for handling API requests.
- Updated `configSchema` in `/apps/cli/src/index.ts` to include `id` and `email` of the user.
- Modified `whoami` API response in `/apps/next/app/api/user/whoami/route.ts` to return the user object from the database.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
