### PR TITLE
speed up clusters page by making it a server component

### DIFF
--- a/apps/next/app/dashboard/clusters/clusters.tsx
+++ b/apps/next/app/dashboard/clusters/clusters.tsx
@@ -17,7 +17,7 @@ import { forwardRef, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useCommandItems } from "@/components/CommandMenu";
 import { useRouter } from "next/navigation";
-import { deleteHetznerCluster } from "./actions";
+import { deleteHetznerCluster, fetchProjectAndClusters } from "./actions";
 import { useFormState, useFormStatus } from "react-dom";
 import { serverActionInitialState } from "@lib/action";
 import { useToast } from "@/components/ui/use-toast";
@@ -36,7 +36,20 @@ interface ClustersProps {
   clusters: HetznerCluster[];
 }
 
-export function Clusters({ clusters }: ClustersProps) {
+export function Clusters({ clusters: initialClusters }: ClustersProps) {
+  const [clusters, setClusters] = useState<HetznerCluster[]>(initialClusters);
+
+  // poll cluster data every 5s--mainly to get cluster statuses updated
+  useEffect(() => {
+    async function fetchData() {
+      const { clusters } = await fetchProjectAndClusters();
+      setClusters(clusters);
+    }
+    fetchData();
+    const interval = setInterval(fetchData, 5000); // Poll every 5000 milliseconds (5 seconds)
+    return () => clearInterval(interval); // Cleanup interval on component unmount
+  }, []);
+
   const [focusedClusterIdx, setFocusedClusterIdx] = useState<number>(0);
   const [focusMode, setFocusMode] = useState<"mouse" | "keyboard">("mouse");
   const tableBodyRef = useRef<HTMLDivElement>(null);

--- a/apps/next/app/dashboard/clusters/page.tsx
+++ b/apps/next/app/dashboard/clusters/page.tsx
@@ -1,45 +1,22 @@
-"use client";
 import * as React from "react";
 import { Onboarding } from "./onboarding";
-import { HetznerCluster, HetznerProject } from "@/app/server/db/schema";
 import { Clusters } from "./clusters";
 import { NoClusters } from "./no-clusters";
-import { useState, useEffect } from "react";
 import { fetchProjectAndClusters } from "./actions";
 
-export default function Page() {
-  const [loaded, setLoaded] = useState(false);
-  const [clusters, setClusters] = useState<HetznerCluster[]>([]);
-  const [hetznerProject, setHetznerProject] = useState<
-    HetznerProject | undefined
-  >(undefined);
-
-  // poll cluster data every 5s--mainly to get cluster statuses updated
-  useEffect(() => {
-    async function fetchData() {
-      const { project, clusters } = await fetchProjectAndClusters();
-      setHetznerProject(project);
-      setClusters(clusters);
-      setLoaded(true);
-    }
-    fetchData();
-    const interval = setInterval(fetchData, 5000); // Poll every 5000 milliseconds (5 seconds)
-    return () => clearInterval(interval); // Cleanup interval on component unmount
-  }, []);
-
+export default async function Page() {
+  const { project, clusters } = await fetchProjectAndClusters();
   return (
     <>
-      {loaded ? (
-        hetznerProject ? (
-          clusters.length > 0 ? (
-            <Clusters clusters={clusters} />
-          ) : (
-            <NoClusters />
-          )
+      {project ? (
+        clusters.length > 0 ? (
+          <Clusters clusters={clusters} />
         ) : (
-          <Onboarding />
+          <NoClusters />
         )
-      ) : null}
+      ) : (
+        <Onboarding />
+      )}
     </>
   );
 }


### PR DESCRIPTION
... and moving the polling loop into the child client component
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 58c216dfa897548988ac6d5e13cf9dc85e89356c  | 
|--------|--------|

### Summary:
Optimized clusters page by converting it to a server component and moving polling logic to the `Clusters` client component.

**Key points**:
- Converted `apps/next/app/dashboard/clusters/page.tsx` to a server component.
- Moved polling logic from `apps/next/app/dashboard/clusters/page.tsx` to `apps/next/app/dashboard/clusters/clusters.tsx`.
- Added `useEffect` in `Clusters` component to poll cluster data every 5 seconds.
- Updated `Clusters` component to initialize state with `initialClusters` and update it with fetched data.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->