### PR TITLE
gateway routes for deployments

### DIFF
--- a/cmd/app/handlers/api/up.go
+++ b/cmd/app/handlers/api/up.go
@@ -311,15 +311,16 @@ func (c customUpResponse) VisitUpResponse(w http.ResponseWriter) (err error) {
 			Ports: []store.Port{
 				{
 					Name:  "http",
-					Port:  80,
+					Port:  8080,
 					Proto: "http",
 				},
 			},
 			ExternalPorts: []store.ExternalPort{
 				{
-					Name:  "http",
-					Port:  80,
-					Proto: "http",
+					PortName: "http",
+					Name:     "expose-8080",
+					Port:     443,
+					Proto:    "https",
 				},
 			},
 			Resources: store.Resources{

--- a/cmd/app/handlers/dashboard.go
+++ b/cmd/app/handlers/dashboard.go
@@ -237,7 +237,7 @@ func (h *DashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ActiveEnv:     &activeEnv,
 		ActiveTabName: templates.TabNameHome,
 		AdditionalScripts: []templates.ScriptTag{
-			templates.ScriptTag{
+			{
 				Src: "/static/script/sse.js",
 			},
 		},

--- a/cmd/app/templates/app-details.templ
+++ b/cmd/app/templates/app-details.templ
@@ -120,7 +120,7 @@ ANOTHER_KEY=another_value" rows="10">{ form.InputValue(data.EnvVars) }</textarea
             <div class="text-xs text-error">{ errors.Get("EnvVars").Error() }</div>
             }
             <div class="flex items-center justify-start gap-2">
-                <button type="submit" class="btn btn-primary btn-sm">Update Variables</button>
+                <button type="submit" class="btn btn-primary btn-sm">update variables and redeploy</button>
                 <span class="htmx-indicator loading loading-ring loading-sm"></span>
             </div>
             if submitError != nil {

--- a/cmd/app/templates/app-details_templ.go
+++ b/cmd/app/templates/app-details_templ.go
@@ -370,7 +370,7 @@ func UpdateAppEnvVarsForm(teamId, envName, appId string, data UpdateAppEnvVarsFo
 				return templ_7745c5c3_Err
 			}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"flex items-center justify-start gap-2\"><button type=\"submit\" class=\"btn btn-primary btn-sm\">Update Variables</button> <span class=\"htmx-indicator loading loading-ring loading-sm\"></span></div>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"flex items-center justify-start gap-2\"><button type=\"submit\" class=\"btn btn-primary btn-sm\">update variables and redeploy</button> <span class=\"htmx-indicator loading loading-ring loading-sm\"></span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/cmd/app/urls/urls.go
+++ b/cmd/app/urls/urls.go
@@ -74,14 +74,14 @@ const DefaultEnvSentinel = "x"
 var _ Url = Home{}
 
 func (u Home) Pattern() string {
-	return "/dashboard/{teamId}/env/{envName}"
+	return "/dashboard/{teamId}/envs/{envName}"
 }
 
 func (u Home) Render() string {
 	if u.TeamId == "" || u.EnvName == "" {
 		panic("teamId and envName are required")
 	}
-	return fmt.Sprintf("/dashboard/%s/env/%s", u.TeamId, u.EnvName)
+	return fmt.Sprintf("/dashboard/%s/envs/%s", u.TeamId, u.EnvName)
 }
 
 type HomeSse struct {
@@ -92,14 +92,14 @@ type HomeSse struct {
 var _ Url = HomeSse{}
 
 func (u HomeSse) Pattern() string {
-	return "/dashboard/{teamId}/env/{envName}/sse"
+	return "/dashboard/{teamId}/envs/{envName}/sse"
 }
 
 func (u HomeSse) Render() string {
 	if u.TeamId == "" || u.EnvName == "" {
 		panic("teamId and envName are required")
 	}
-	return fmt.Sprintf("/dashboard/%s/env/%s/sse", u.TeamId, u.EnvName)
+	return fmt.Sprintf("/dashboard/%s/envs/%s/sse", u.TeamId, u.EnvName)
 }
 
 type NewServer struct {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update gateway routes and URL patterns for deployments, including port changes and UI text updates.
> 
>   - **Gateway Routes**:
>     - Update `Port` from 80 to 8080 and `ExternalPort` from 80 to 443 in `cmd/app/handlers/api/up.go`.
>     - Add functions `hostnameForDeployment`, `httpRoutesForDeployment`, `ensureHttpRoutesForDeployment`, `servicePortsForDeployment`, and `ensureServiceForDeployment` in `talos.go` to manage HTTP routes and services for deployments.
>   - **URL Patterns**:
>     - Change URL pattern from `/dashboard/{teamId}/env/{envName}` to `/dashboard/{teamId}/envs/{envName}` in `urls.go`.
>   - **UI Changes**:
>     - Update button text to "update variables and redeploy" in `app-details.templ` and `app-details_templ.go`.
>   - **Miscellaneous**:
>     - Remove redundant `ScriptTag` declaration in `dashboard.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onmetal-dev%2Fmetal&utm_source=github&utm_medium=referral)<sup> for a2554a4393886bab505ffac11c65e18b459cc6d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->